### PR TITLE
[Fix] aclocal is missing

### DIFF
--- a/patch_ncmi_deb.sh
+++ b/patch_ncmi_deb.sh
@@ -28,7 +28,7 @@ USAGE_LIBS=(
 
 cd "$TMP"
 apt source vlc
-sudo apt install libmpg123-dev libflac-dev libmpeg2-4-dev libgnutls28-dev libsoxr-dev libsamplerate0-dev libasound2-dev
+sudo apt install libmpg123-dev libflac-dev libmpeg2-4-dev libgnutls28-dev libsoxr-dev libsamplerate0-dev libasound2-dev automake
 cd vlc-3*
 cat > ncm.patch <<EOF
 diff --git a/modules/access/http/resource.c b/modules/access/http/resource.c


### PR DESCRIPTION
执行过程有报错：
```
WARNING: 'aclocal-1.16' is missing on your system.
```
会导致编译失败，根据[这里](https://stackoverflow.com/questions/33278928/how-to-overcome-aclocal-1-15-is-missing-on-your-system-warning)的提示，添加了`automake`依赖，Ubuntu 22.04验证OK。